### PR TITLE
docs: use `<time>` tag

### DIFF
--- a/_includes/article-info.html
+++ b/_includes/article-info.html
@@ -52,7 +52,7 @@
           {%- assign __locale = site.data.locale.ARTICLE_DATE_FORMAT } -%}
           {%- include snippets/locale-to-string.html -%}
           {%- if post -%}
-            <span>{{ cur_page.date | date: __return }}</span>
+            <time datetime="{{ cur_page.date | date_to_xmlschema }}">{{ cur_page.date | date: __return }}</time>
           {%- elsif page -%}
             <time datetime="{{ page.date | date_to_xmlschema }}"
               itemprop="datePublished">{{ cur_page.date | date: __return }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7c3f859d-bcd6-4581-818d-e058d7d8c501)

## 개요

post 의 경우에도 [`<time>` 태그](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)를 적용합니다.

## 예상 효과

[스크린 리더 접근성이 향상됩니다.](https://shkspr.mobi/blog/2020/12/making-time-more-accessible/)

## 기타

![image](https://github.com/user-attachments/assets/c0d3d2e3-d047-4cfb-b5b3-0a64377c611c)

이어지는 [iso8601](https://en.wikipedia.org/wiki/ISO_8601)의 의지...!

<details><summary>컨테이너로 로컬 서버 띄우기</summary>

```sh
$ podman run -p 4000:4000 -v (pwd):/site:Z docker.io/bretfisher/jekyll-serve
```

</details> 